### PR TITLE
Allows simplified strategies for controlling the base directory (#369)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -324,6 +324,9 @@ All Asciidoctor tasks will have the following methods and properties:
 asciidoctorj:: a task extension which allows a task to extend of override global configuration for Asciidoctor tasks.
   This allow extensive flexibility. Any thing that can be configured in the global `asciidoctorj` extension can also be configured here.
 attributes:: A shortcut for `asciidoctorj.attributes`.
+baseDir:: Base directory for asciidoctor jail.
+  The base directory will be the project directory, but default, but can be set to any other directory. It can also be
+  set to follow any of the following strategies: `baseDirIsRootProjectDir()`, `baseDirIsProjectDir()`, `baseDirFollowsSourceDir()`
 configurations:: Specify additional configurations
   These configurations will be added to the classpath when the task is executed.
 copyAllResources:: Copy all resources to the output directory

--- a/asciidoctor-gradle-base/src/main/groovy/org/asciidoctor/gradle/base/BaseDirStrategy.groovy
+++ b/asciidoctor-gradle-base/src/main/groovy/org/asciidoctor/gradle/base/BaseDirStrategy.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.asciidoctor.gradle.base
+
+import groovy.transform.CompileStatic
+
+/** Strategy to set where the base directory should be relative to
+ * a project.
+ *
+ * @author Schalk W. Cronjé
+ *
+ * @since 2.2.0
+ */
+@CompileStatic
+interface BaseDirStrategy {
+
+    /** Base directory location.
+     *
+     * @return Base directory
+     */
+    File getBaseDir()
+}

--- a/asciidoctor-gradle-base/src/main/groovy/org/asciidoctor/gradle/base/basedir/BaseDirFollowsProject.groovy
+++ b/asciidoctor-gradle-base/src/main/groovy/org/asciidoctor/gradle/base/basedir/BaseDirFollowsProject.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.asciidoctor.gradle.base.basedir
+
+import groovy.transform.CompileStatic
+import org.asciidoctor.gradle.base.BaseDirStrategy
+import org.gradle.api.Project
+
+/** Strategy where the project directory is always to be base directory
+ * for asciidoctor conversions.
+ *
+ * @author Schalk W. Cronjé
+ *
+ * @since 2.2.0
+ */
+@CompileStatic
+class BaseDirFollowsProject implements BaseDirStrategy {
+
+    private final Project project
+
+    BaseDirFollowsProject(Project project) {
+        this.project = project
+    }
+
+    /** Base directory location.
+     *
+     * @return Base directory
+     */
+    @Override
+    File getBaseDir() {
+        project.projectDir
+    }
+}

--- a/asciidoctor-gradle-base/src/main/groovy/org/asciidoctor/gradle/base/basedir/BaseDirFollowsRootProject.groovy
+++ b/asciidoctor-gradle-base/src/main/groovy/org/asciidoctor/gradle/base/basedir/BaseDirFollowsRootProject.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.asciidoctor.gradle.base.basedir
+
+import groovy.transform.CompileStatic
+import org.asciidoctor.gradle.base.BaseDirStrategy
+import org.gradle.api.Project
+
+/** Strategy where the root project is always the base directory
+ * for asciidoctor conversions
+ *
+ * @author Schalk W. Cronjé
+ *
+ * @since 2.2.0
+ */
+@CompileStatic
+class BaseDirFollowsRootProject implements BaseDirStrategy {
+
+    private final Project project
+
+    BaseDirFollowsRootProject(Project project) {
+        this.project = project
+    }
+
+    /** Base directory location.
+     *
+     * @return Base directory
+     */
+    @Override
+    File getBaseDir() {
+        project.rootDir
+    }
+}

--- a/asciidoctor-gradle-base/src/main/groovy/org/asciidoctor/gradle/base/basedir/BaseDirIsFixedPath.groovy
+++ b/asciidoctor-gradle-base/src/main/groovy/org/asciidoctor/gradle/base/basedir/BaseDirIsFixedPath.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.asciidoctor.gradle.base.basedir
+
+import groovy.transform.CompileStatic
+import org.asciidoctor.gradle.base.BaseDirStrategy
+import org.gradle.api.provider.Provider
+
+/** Strategy where a lazy-evaluated fixed path is used as the base
+ * directory for asciidoctor conversions.
+ *
+ * @author Schalk W. Cronjé
+ *
+ * @since 2.2.0
+ */
+@CompileStatic
+class BaseDirIsFixedPath implements BaseDirStrategy {
+
+    private final Provider<File> location
+
+    BaseDirIsFixedPath(Provider<File> lazyResolvedLocation) {
+        this.location = lazyResolvedLocation
+    }
+
+    /** Base directory location.
+     *
+     * @return Base directory
+     */
+    @Override
+    File getBaseDir() {
+        location.get()
+    }
+}

--- a/asciidoctor-gradle-jvm/src/test/groovy/org/asciidoctor/gradle/jvm/AsciidoctorTaskSpec.groovy
+++ b/asciidoctor-gradle-jvm/src/test/groovy/org/asciidoctor/gradle/jvm/AsciidoctorTaskSpec.groovy
@@ -17,7 +17,6 @@ package org.asciidoctor.gradle.jvm
 
 import org.gradle.api.GradleException
 import org.gradle.api.Project
-import org.gradle.api.file.FileCollection
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
 
@@ -33,8 +32,6 @@ class AsciidoctorTaskSpec extends Specification {
     private static final String ASCIIDOCTOR = 'asciidoctor'
     private static final String ASCIIDOC_RESOURCES_DIR = 'asciidoctor-gradle-jvm/src/test/resources/src/asciidoc'
     private static final String ASCIIDOC_BUILD_DIR = 'build/asciidoc'
-    private static final String ASCIIDOC_SAMPLE_FILE = 'sample.asciidoc'
-    private static final String ASCIIDOC_SAMPLE2_FILE = 'subdir/sample2.ad'
 
     Project project = ProjectBuilder.builder().withName('test').build()
 
@@ -60,6 +57,67 @@ class AsciidoctorTaskSpec extends Specification {
 
     void cleanup() {
         System.out = originSystemOut
+    }
+
+    void 'Base directory is project directory by default'() {
+        when:
+        AsciidoctorTask task = asciidoctorTask {
+        }
+
+        then:
+        task.baseDir == project.projectDir
+    }
+
+    void 'Base directory can be root project directory'() {
+        when:
+        AsciidoctorTask task = asciidoctorTask {
+            baseDir baseDirIsRootProjectDir()
+        }
+
+        then:
+        task.baseDir == project.rootProject.projectDir
+    }
+
+    void 'Base directory can be project directory'() {
+        when:
+        AsciidoctorTask task = asciidoctorTask {
+            baseDir baseDirIsRootProjectDir()
+            baseDir baseDirIsProjectDir()
+        }
+
+        then:
+        task.baseDir == project.rootProject.projectDir
+    }
+
+    void 'Base directory can be a fixed directory'() {
+        when:
+        AsciidoctorTask task = asciidoctorTask {
+            baseDir 'foo'
+        }
+
+        then:
+        task.baseDir == project.file('foo')
+    }
+
+    void 'Base directory can be source directory'() {
+        when:
+        AsciidoctorTask task = asciidoctorTask {
+            baseDir baseDirFollowsSourceDir()
+        }
+
+        then:
+        task.baseDir == task.sourceDir
+    }
+
+    void 'Base directory can be source directory within a temporary working directory'() {
+        when:
+        AsciidoctorTask task = asciidoctorTask {
+            baseDir baseDirFollowsSourceDir()
+            useIntermediateWorkDir()
+        }
+
+        then:
+        task.baseDir == project.file("${project.buildDir}/tmp/${task.name}.intermediate")
     }
 
     void "Allow setting of options via method"() {
@@ -167,8 +225,8 @@ class AsciidoctorTaskSpec extends Specification {
         when:
         asciidoctorTask {
             options = [
-                doctype: 'book',
-                attributes: 'toc=right source-highlighter=coderay toc-title=Table\\ of\\ Contents'
+                    doctype   : 'book',
+                    attributes: 'toc=right source-highlighter=coderay toc-title=Table\\ of\\ Contents'
             ]
         }
 
@@ -180,9 +238,9 @@ class AsciidoctorTaskSpec extends Specification {
         when:
         asciidoctorTask {
             options = [doctype: 'book', attributes: [
-                'toc=right',
-                'source-highlighter=coderay',
-                'toc-title=Table of Contents'
+                    'toc=right',
+                    'source-highlighter=coderay',
+                    'toc-title=Table of Contents'
             ]]
         }
 
@@ -355,39 +413,6 @@ class AsciidoctorTaskSpec extends Specification {
         then:
         task.asciidoctorj.asGemPath() == project.projectDir.absolutePath
         !systemOut.toString().contains('deprecated')
-    }
-
-    void "Method `sourceDocumentNames` should resolve descendant files of `sourceDir` if supplied as relatives"() {
-        when: 'I specify two files relative to sourceDir,including one in a subfolder'
-        AsciidoctorTask task = asciidoctorTask {
-            sourceDir srcDir
-            sources {
-                include ASCIIDOC_SAMPLE_FILE
-                include ASCIIDOC_SAMPLE2_FILE
-            }
-        }
-        def fileCollection = task.sourceFileTree
-
-        then: 'both files should be in collection, but any other files found in folder should be excluded'
-        fileCollection.contains(new File(srcDir, ASCIIDOC_SAMPLE_FILE).canonicalFile)
-        fileCollection.contains(new File(srcDir, ASCIIDOC_SAMPLE2_FILE).canonicalFile)
-        !fileCollection.contains(new File(srcDir, 'sample-docinfo.xml').canonicalFile)
-        fileCollection.files.size() == 2
-    }
-
-    void 'Can configure secondary sources'() {
-        final String secSrc = 'secondary.txt'
-        when: 'Secondary sources are specified'
-        AsciidoctorTask task = asciidoctorTask {
-            sourceDir srcDir
-            secondarySources {
-                include secSrc
-            }
-        }
-        FileCollection fileCollection = task.secondarySourceFileTree
-
-        then: 'Default patterns are ignored'
-        fileCollection.contains(new File(srcDir, secSrc).canonicalFile)
     }
 
     void 'When attribute providers are registered on the task, then global ones will not be used.'() {


### PR DESCRIPTION
Even with standardisation in 2.0, there are use cases which confuse users
or surprises their contextual expectations. Therefore it is now possible
to use specific strategies for controlling the base directory:

- Base directory is root project directory
- Base directory is project directtory
- Base directory follows the source directory even if an intermediate
  working directory is being used.

By default the base directory will still be the project directory as has
been the case for 1.5 & 2.0. The base directory can also be set to be any
arbitrary directory as required.